### PR TITLE
Bump governance client to `v0.2.28`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18642,6 +18642,7 @@
     },
     "node_modules/gc-stats/node_modules/abbrev": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
       "license": "ISC",
@@ -18649,6 +18650,7 @@
     },
     "node_modules/gc-stats/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
       "license": "MIT",
@@ -18659,6 +18661,7 @@
     },
     "node_modules/gc-stats/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC",
@@ -18666,6 +18669,7 @@
     },
     "node_modules/gc-stats/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "inBundle": true,
       "license": "ISC",
@@ -18677,6 +18681,7 @@
     },
     "node_modules/gc-stats/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
       "license": "MIT",
@@ -18684,6 +18689,7 @@
     },
     "node_modules/gc-stats/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
@@ -18695,6 +18701,7 @@
     },
     "node_modules/gc-stats/node_modules/chownr": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "inBundle": true,
       "license": "ISC",
@@ -18702,6 +18709,7 @@
     },
     "node_modules/gc-stats/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
       "license": "MIT",
@@ -18712,6 +18720,7 @@
     },
     "node_modules/gc-stats/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
       "license": "MIT",
@@ -18719,6 +18728,7 @@
     },
     "node_modules/gc-stats/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
       "license": "ISC",
@@ -18726,6 +18736,7 @@
     },
     "node_modules/gc-stats/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
       "license": "MIT",
@@ -18733,6 +18744,7 @@
     },
     "node_modules/gc-stats/node_modules/debug": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "inBundle": true,
       "license": "MIT",
@@ -18743,6 +18755,7 @@
     },
     "node_modules/gc-stats/node_modules/deep-extend": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
       "license": "MIT",
@@ -18753,6 +18766,7 @@
     },
     "node_modules/gc-stats/node_modules/delegates": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
       "license": "MIT",
@@ -18760,6 +18774,7 @@
     },
     "node_modules/gc-stats/node_modules/detect-libc": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "inBundle": true,
       "license": "Apache-2.0",
@@ -18773,6 +18788,7 @@
     },
     "node_modules/gc-stats/node_modules/fs-minipass": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "inBundle": true,
       "license": "ISC",
@@ -18783,6 +18799,7 @@
     },
     "node_modules/gc-stats/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
       "license": "ISC",
@@ -18790,6 +18807,7 @@
     },
     "node_modules/gc-stats/node_modules/gauge": {
       "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
       "license": "ISC",
@@ -18807,6 +18825,7 @@
     },
     "node_modules/gc-stats/node_modules/glob": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "inBundle": true,
       "license": "ISC",
@@ -18825,6 +18844,7 @@
     },
     "node_modules/gc-stats/node_modules/has-unicode": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
       "license": "ISC",
@@ -18832,6 +18852,7 @@
     },
     "node_modules/gc-stats/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "inBundle": true,
       "license": "MIT",
@@ -18845,6 +18866,7 @@
     },
     "node_modules/gc-stats/node_modules/ignore-walk": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "inBundle": true,
       "license": "ISC",
@@ -18855,6 +18877,7 @@
     },
     "node_modules/gc-stats/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
       "license": "ISC",
@@ -18866,6 +18889,7 @@
     },
     "node_modules/gc-stats/node_modules/inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "inBundle": true,
       "license": "ISC",
@@ -18873,6 +18897,7 @@
     },
     "node_modules/gc-stats/node_modules/ini": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "inBundle": true,
       "license": "ISC",
@@ -18883,6 +18908,7 @@
     },
     "node_modules/gc-stats/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
       "license": "MIT",
@@ -18896,6 +18922,7 @@
     },
     "node_modules/gc-stats/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
       "license": "MIT",
@@ -18903,6 +18930,7 @@
     },
     "node_modules/gc-stats/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
       "license": "ISC",
@@ -18916,6 +18944,7 @@
     },
     "node_modules/gc-stats/node_modules/minimist": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "inBundle": true,
       "license": "MIT",
@@ -18923,6 +18952,7 @@
     },
     "node_modules/gc-stats/node_modules/minipass": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "inBundle": true,
       "license": "ISC",
@@ -18934,6 +18964,7 @@
     },
     "node_modules/gc-stats/node_modules/minizlib": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "inBundle": true,
       "license": "MIT",
@@ -18944,6 +18975,7 @@
     },
     "node_modules/gc-stats/node_modules/mkdirp": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "inBundle": true,
       "license": "MIT",
@@ -18957,6 +18989,7 @@
     },
     "node_modules/gc-stats/node_modules/ms": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "inBundle": true,
       "license": "MIT",
@@ -18964,6 +18997,7 @@
     },
     "node_modules/gc-stats/node_modules/needle": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
       "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
       "inBundle": true,
       "license": "MIT",
@@ -18982,6 +19016,7 @@
     },
     "node_modules/gc-stats/node_modules/node-pre-gyp": {
       "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
       "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -19004,6 +19039,7 @@
     },
     "node_modules/gc-stats/node_modules/nopt": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "inBundle": true,
       "license": "ISC",
@@ -19018,6 +19054,7 @@
     },
     "node_modules/gc-stats/node_modules/npm-bundled": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "inBundle": true,
       "license": "ISC",
@@ -19025,6 +19062,7 @@
     },
     "node_modules/gc-stats/node_modules/npm-packlist": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "inBundle": true,
       "license": "ISC",
@@ -19036,6 +19074,7 @@
     },
     "node_modules/gc-stats/node_modules/npmlog": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
       "license": "ISC",
@@ -19049,6 +19088,7 @@
     },
     "node_modules/gc-stats/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
       "license": "MIT",
@@ -19059,6 +19099,7 @@
     },
     "node_modules/gc-stats/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
       "license": "MIT",
@@ -19069,6 +19110,7 @@
     },
     "node_modules/gc-stats/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
       "license": "ISC",
@@ -19079,6 +19121,7 @@
     },
     "node_modules/gc-stats/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
       "license": "MIT",
@@ -19089,6 +19132,7 @@
     },
     "node_modules/gc-stats/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
       "license": "MIT",
@@ -19099,6 +19143,7 @@
     },
     "node_modules/gc-stats/node_modules/osenv": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
       "license": "ISC",
@@ -19110,6 +19155,7 @@
     },
     "node_modules/gc-stats/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
       "license": "MIT",
@@ -19120,6 +19166,7 @@
     },
     "node_modules/gc-stats/node_modules/process-nextick-args": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
       "license": "MIT",
@@ -19127,6 +19174,7 @@
     },
     "node_modules/gc-stats/node_modules/rc": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -19143,6 +19191,7 @@
     },
     "node_modules/gc-stats/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "inBundle": true,
       "license": "MIT",
@@ -19150,6 +19199,7 @@
     },
     "node_modules/gc-stats/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
@@ -19166,6 +19216,7 @@
     },
     "node_modules/gc-stats/node_modules/rimraf": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "inBundle": true,
       "license": "ISC",
@@ -19179,6 +19230,7 @@
     },
     "node_modules/gc-stats/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
       "license": "MIT",
@@ -19186,6 +19238,7 @@
     },
     "node_modules/gc-stats/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT",
@@ -19193,6 +19246,7 @@
     },
     "node_modules/gc-stats/node_modules/sax": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "inBundle": true,
       "license": "ISC",
@@ -19200,6 +19254,7 @@
     },
     "node_modules/gc-stats/node_modules/semver": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "inBundle": true,
       "license": "ISC",
@@ -19210,6 +19265,7 @@
     },
     "node_modules/gc-stats/node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
       "license": "ISC",
@@ -19217,6 +19273,7 @@
     },
     "node_modules/gc-stats/node_modules/signal-exit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
       "license": "ISC",
@@ -19224,6 +19281,7 @@
     },
     "node_modules/gc-stats/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
@@ -19234,6 +19292,7 @@
     },
     "node_modules/gc-stats/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
@@ -19249,6 +19308,7 @@
     },
     "node_modules/gc-stats/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
       "license": "MIT",
@@ -19262,6 +19322,7 @@
     },
     "node_modules/gc-stats/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
       "license": "MIT",
@@ -19272,6 +19333,7 @@
     },
     "node_modules/gc-stats/node_modules/tar": {
       "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
       "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "inBundle": true,
       "license": "ISC",
@@ -19291,6 +19353,7 @@
     },
     "node_modules/gc-stats/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
       "license": "MIT",
@@ -19298,6 +19361,7 @@
     },
     "node_modules/gc-stats/node_modules/wide-align": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "inBundle": true,
       "license": "ISC",
@@ -19308,6 +19372,7 @@
     },
     "node_modules/gc-stats/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
       "license": "ISC",
@@ -19315,6 +19380,7 @@
     },
     "node_modules/gc-stats/node_modules/yallist": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
       "license": "ISC",
@@ -56094,24 +56160,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "optional": true,
@@ -56122,12 +56192,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "optional": true,
@@ -56138,36 +56210,42 @@
         },
         "chownr": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "optional": true,
@@ -56177,24 +56255,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "optional": true,
@@ -56204,12 +56286,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "optional": true,
@@ -56226,6 +56310,7 @@
         },
         "glob": {
           "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "optional": true,
@@ -56240,12 +56325,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "optional": true,
@@ -56255,6 +56342,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "optional": true,
@@ -56264,6 +56352,7 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "optional": true,
@@ -56274,18 +56363,21 @@
         },
         "inherits": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "bundled": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "optional": true,
@@ -56295,12 +56387,14 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "optional": true,
@@ -56310,12 +56404,14 @@
         },
         "minimist": {
           "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "optional": true,
@@ -56326,6 +56422,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "optional": true,
@@ -56335,6 +56432,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "optional": true,
@@ -56344,12 +56442,14 @@
         },
         "ms": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
           "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
           "bundled": true,
           "optional": true,
@@ -56361,6 +56461,7 @@
         },
         "node-pre-gyp": {
           "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
           "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
           "bundled": true,
           "optional": true,
@@ -56379,6 +56480,7 @@
         },
         "nopt": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "optional": true,
@@ -56389,12 +56491,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "bundled": true,
           "optional": true,
@@ -56405,6 +56509,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "optional": true,
@@ -56417,18 +56522,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "optional": true,
@@ -56438,18 +56546,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "optional": true,
@@ -56460,18 +56571,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "optional": true,
@@ -56484,6 +56598,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "optional": true
@@ -56492,6 +56607,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "optional": true,
@@ -56507,6 +56623,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "optional": true,
@@ -56516,42 +56633,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "optional": true,
@@ -56561,6 +56685,7 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "optional": true,
@@ -56572,6 +56697,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "optional": true,
@@ -56581,12 +56707,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "optional": true,
@@ -56602,12 +56730,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "optional": true,
@@ -56617,12 +56747,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@dydxprotocol/governance": "^0.2.26",
+        "@dydxprotocol/governance": "^0.2.27",
         "@storybook/react": "^6.2.8",
         "@testing-library/jest-dom": "^5.11.10",
         "@testing-library/react": "^11.2.6",
@@ -1614,9 +1614,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dydxprotocol/governance": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.26.tgz",
-      "integrity": "sha512-JnQz2XiS3KZM45QTkQC7PDZIZbhZvqOZjhCLsqZUdjsASjlSCdwYRfctybey7119GcKH5GcIlUh94dwVTWHQHg==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.27.tgz",
+      "integrity": "sha512-bQx8c2XYimrm9BGCCheipyLGUmHAk+N6NLbfcWp35lSqZcXfNcSSQ6gPXccwekAKhLzFgX67ALKYrXMJgAuu2A==",
       "dependencies": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",
@@ -3446,6 +3446,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4557,6 +4558,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -12137,6 +12141,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -12481,6 +12486,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -12907,8 +12913,10 @@
       "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.1.tgz",
       "integrity": "sha512-BbtB6t0iqAwGwygDenJl9zmlk7vpKWIRSycULmkAOn2RUaF6+bqETprl0qcIqQmY5CTqSwKanaxkLXYWiffAfQ==",
       "dependencies": {
+        "immutable": "^3.8.1 || ^4.0.0-rc.1",
         "lodash.isequalwith": "^4.4.0",
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.7.2",
+        "seamless-immutable": "^7.1.3"
       },
       "optionalDependencies": {
         "immutable": "^3.8.1 || ^4.0.0-rc.1",
@@ -15112,6 +15120,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -15163,6 +15174,7 @@
       "dependencies": {
         "cross-spawn": "^5.1.0",
         "electron": "^1.6.11",
+        "headless": "https://github.com/paulkernfeld/node-headless/tarball/master",
         "ndjson": "^1.5.0"
       },
       "optionalDependencies": {
@@ -15845,7 +15857,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -16159,6 +16172,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -17839,6 +17855,9 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -18623,12 +18642,14 @@
     },
     "node_modules/gc-stats/node_modules/abbrev": {
       "version": "1.1.1",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18638,12 +18659,14 @@
     },
     "node_modules/gc-stats/node_modules/aproba": {
       "version": "1.2.0",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18654,12 +18677,14 @@
     },
     "node_modules/gc-stats/node_modules/balanced-match": {
       "version": "1.0.0",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18670,12 +18695,14 @@
     },
     "node_modules/gc-stats/node_modules/chownr": {
       "version": "1.1.1",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/code-point-at": {
       "version": "1.1.0",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18685,24 +18712,28 @@
     },
     "node_modules/gc-stats/node_modules/concat-map": {
       "version": "0.0.1",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/core-util-is": {
       "version": "1.0.2",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/debug": {
       "version": "4.1.1",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18712,6 +18743,7 @@
     },
     "node_modules/gc-stats/node_modules/deep-extend": {
       "version": "0.6.0",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18721,12 +18753,14 @@
     },
     "node_modules/gc-stats/node_modules/delegates": {
       "version": "1.0.0",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/detect-libc": {
       "version": "1.0.3",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "inBundle": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -18739,6 +18773,7 @@
     },
     "node_modules/gc-stats/node_modules/fs-minipass": {
       "version": "1.2.5",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18748,12 +18783,14 @@
     },
     "node_modules/gc-stats/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/gauge": {
       "version": "2.7.4",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18770,6 +18807,7 @@
     },
     "node_modules/gc-stats/node_modules/glob": {
       "version": "7.1.3",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18787,12 +18825,14 @@
     },
     "node_modules/gc-stats/node_modules/has-unicode": {
       "version": "2.0.1",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18805,6 +18845,7 @@
     },
     "node_modules/gc-stats/node_modules/ignore-walk": {
       "version": "3.0.1",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18814,6 +18855,7 @@
     },
     "node_modules/gc-stats/node_modules/inflight": {
       "version": "1.0.6",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18824,12 +18866,14 @@
     },
     "node_modules/gc-stats/node_modules/inherits": {
       "version": "2.0.3",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/ini": {
       "version": "1.3.5",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18839,6 +18883,7 @@
     },
     "node_modules/gc-stats/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18851,12 +18896,14 @@
     },
     "node_modules/gc-stats/node_modules/isarray": {
       "version": "1.0.0",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/minimatch": {
       "version": "3.0.4",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18869,12 +18916,14 @@
     },
     "node_modules/gc-stats/node_modules/minimist": {
       "version": "0.0.8",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/minipass": {
       "version": "2.3.5",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18885,6 +18934,7 @@
     },
     "node_modules/gc-stats/node_modules/minizlib": {
       "version": "1.2.1",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18894,6 +18944,7 @@
     },
     "node_modules/gc-stats/node_modules/mkdirp": {
       "version": "0.5.1",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18906,12 +18957,14 @@
     },
     "node_modules/gc-stats/node_modules/ms": {
       "version": "2.1.1",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/needle": {
       "version": "2.3.1",
+      "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18929,6 +18982,7 @@
     },
     "node_modules/gc-stats/node_modules/node-pre-gyp": {
       "version": "0.13.0",
+      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -18950,6 +19004,7 @@
     },
     "node_modules/gc-stats/node_modules/nopt": {
       "version": "4.0.1",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18963,12 +19018,14 @@
     },
     "node_modules/gc-stats/node_modules/npm-bundled": {
       "version": "1.0.6",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/npm-packlist": {
       "version": "1.4.1",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18979,6 +19036,7 @@
     },
     "node_modules/gc-stats/node_modules/npmlog": {
       "version": "4.1.2",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -18991,6 +19049,7 @@
     },
     "node_modules/gc-stats/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19000,6 +19059,7 @@
     },
     "node_modules/gc-stats/node_modules/object-assign": {
       "version": "4.1.1",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19009,6 +19069,7 @@
     },
     "node_modules/gc-stats/node_modules/once": {
       "version": "1.4.0",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19018,6 +19079,7 @@
     },
     "node_modules/gc-stats/node_modules/os-homedir": {
       "version": "1.0.2",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19027,6 +19089,7 @@
     },
     "node_modules/gc-stats/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19036,6 +19099,7 @@
     },
     "node_modules/gc-stats/node_modules/osenv": {
       "version": "0.1.5",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19046,6 +19110,7 @@
     },
     "node_modules/gc-stats/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19055,12 +19120,14 @@
     },
     "node_modules/gc-stats/node_modules/process-nextick-args": {
       "version": "2.0.0",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/rc": {
       "version": "1.2.8",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
@@ -19076,12 +19143,14 @@
     },
     "node_modules/gc-stats/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/readable-stream": {
       "version": "2.3.6",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19097,6 +19166,7 @@
     },
     "node_modules/gc-stats/node_modules/rimraf": {
       "version": "2.6.3",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19109,24 +19179,28 @@
     },
     "node_modules/gc-stats/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/sax": {
       "version": "1.2.4",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/semver": {
       "version": "5.7.0",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19136,18 +19210,21 @@
     },
     "node_modules/gc-stats/node_modules/set-blocking": {
       "version": "2.0.0",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/signal-exit": {
       "version": "3.0.2",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/string_decoder": {
       "version": "1.1.1",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19157,6 +19234,7 @@
     },
     "node_modules/gc-stats/node_modules/string-width": {
       "version": "1.0.2",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19171,6 +19249,7 @@
     },
     "node_modules/gc-stats/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19183,6 +19262,7 @@
     },
     "node_modules/gc-stats/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19192,6 +19272,7 @@
     },
     "node_modules/gc-stats/node_modules/tar": {
       "version": "4.4.8",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19210,12 +19291,14 @@
     },
     "node_modules/gc-stats/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/wide-align": {
       "version": "1.1.3",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -19225,12 +19308,14 @@
     },
     "node_modules/gc-stats/node_modules/wrappy": {
       "version": "1.0.2",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/gc-stats/node_modules/yallist": {
       "version": "3.0.3",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
       "license": "ISC",
       "optional": true
@@ -21226,6 +21311,7 @@
         "@mapbox/node-pre-gyp": "^1.0.5",
         "debug": "^4.1.1",
         "dlv": "^1.1.3",
+        "electron-webrtc": "^0.3.0",
         "ipfs-core": "^0.8.0",
         "ipfs-core-types": "^0.5.2",
         "ipfs-grpc-server": "^0.3.4",
@@ -21238,7 +21324,10 @@
         "libp2p-delegated-content-routing": "^0.10.0",
         "libp2p-delegated-peer-routing": "^0.9.0",
         "libp2p-webrtc-star": "^0.22.2",
-        "multiaddr": "^9.0.1"
+        "multiaddr": "^9.0.1",
+        "prom-client": "^12.0.0",
+        "prometheus-gc-stats": "^0.6.0",
+        "wrtc": "^0.4.6"
       },
       "optionalDependencies": {
         "electron-webrtc": "^0.3.0",
@@ -21404,6 +21493,7 @@
         "multihashing-async": "^2.1.2",
         "native-abort-controller": "^1.0.3",
         "parse-duration": "^1.0.0",
+        "prom-client": "^12.0.0",
         "stream-to-it": "^0.2.2",
         "uint8arrays": "^2.1.3",
         "uri-to-multiaddr": "^5.0.0"
@@ -21892,6 +21982,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -24044,6 +24137,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -25803,6 +25897,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -25932,6 +26027,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -28302,6 +28400,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -32090,6 +32191,9 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "dependencies": {
+        "clipboard": "^2.0.0"
+      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -32212,6 +32316,7 @@
       "integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
       "optional": true,
       "dependencies": {
+        "gc-stats": "^1.4.0",
         "optional": "^0.1.3"
       },
       "engines": {
@@ -33389,6 +33494,7 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
+        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -38946,8 +39052,10 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -39037,6 +39145,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -39551,6 +39660,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -40119,6 +40229,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -40727,6 +40840,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -40956,6 +41072,7 @@
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
+        "domexception": "^1.0.1",
         "node-pre-gyp": "^0.13.0"
       },
       "engines": {
@@ -42601,9 +42718,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dydxprotocol/governance": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.26.tgz",
-      "integrity": "sha512-JnQz2XiS3KZM45QTkQC7PDZIZbhZvqOZjhCLsqZUdjsASjlSCdwYRfctybey7119GcKH5GcIlUh94dwVTWHQHg==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.27.tgz",
+      "integrity": "sha512-bQx8c2XYimrm9BGCCheipyLGUmHAk+N6NLbfcWp35lSqZcXfNcSSQ6gPXccwekAKhLzFgX67ALKYrXMJgAuu2A==",
       "requires": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",
@@ -45473,6 +45590,7 @@
       "integrity": "sha512-IWnb10ImrzRMT2qw9785p3wYEI6U9gjsg6H2zKcRJQP5dEboqeX3OFjUKfXkaIWii4nz8MtJjBg5t4BdEYqLdw==",
       "dev": true,
       "requires": {
+        "@babel/core": "^7.12.10",
         "@babel/generator": "^7.12.11",
         "@babel/parser": "^7.12.11",
         "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -55976,21 +56094,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56000,11 +56122,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56014,31 +56138,37 @@
         },
         "chownr": {
           "version": "1.1.1",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56047,21 +56177,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56070,11 +56204,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56090,6 +56226,7 @@
         },
         "glob": {
           "version": "7.1.3",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56103,11 +56240,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56116,6 +56255,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56124,6 +56264,7 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56133,16 +56274,19 @@
         },
         "inherits": {
           "version": "2.0.3",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "bundled": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56151,11 +56295,13 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56164,11 +56310,13 @@
         },
         "minimist": {
           "version": "0.0.8",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56178,6 +56326,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56186,6 +56335,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56194,11 +56344,13 @@
         },
         "ms": {
           "version": "2.1.1",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.1",
+          "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56209,6 +56361,7 @@
         },
         "node-pre-gyp": {
           "version": "0.13.0",
+          "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56226,6 +56379,7 @@
         },
         "nopt": {
           "version": "4.0.1",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56235,11 +56389,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56249,6 +56405,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56260,16 +56417,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56278,16 +56438,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56297,16 +56460,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56318,6 +56484,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "optional": true
             }
@@ -56325,6 +56492,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56339,6 +56507,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56347,36 +56516,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56385,6 +56561,7 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56395,6 +56572,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56403,11 +56581,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56422,11 +56602,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -56435,11 +56617,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "optional": true
         }
@@ -63508,6 +63692,7 @@
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -63562,6 +63747,7 @@
       "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@dydxprotocol/governance": "^0.2.27",
+        "@dydxprotocol/governance": "^0.2.28",
         "@storybook/react": "^6.2.8",
         "@testing-library/jest-dom": "^5.11.10",
         "@testing-library/react": "^11.2.6",
@@ -1614,9 +1614,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dydxprotocol/governance": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.27.tgz",
-      "integrity": "sha512-bQx8c2XYimrm9BGCCheipyLGUmHAk+N6NLbfcWp35lSqZcXfNcSSQ6gPXccwekAKhLzFgX67ALKYrXMJgAuu2A==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.28.tgz",
+      "integrity": "sha512-I4Iu4t9CdcoGwAWJLhPinGeXqFlgkX2rO+ua3eIk+aTv0/WrDWtPHPvgIVpl9n8VNXdEi2FcNi+C6GS6IGf0/A==",
       "dependencies": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",
@@ -42784,9 +42784,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dydxprotocol/governance": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.27.tgz",
-      "integrity": "sha512-bQx8c2XYimrm9BGCCheipyLGUmHAk+N6NLbfcWp35lSqZcXfNcSSQ6gPXccwekAKhLzFgX67ALKYrXMJgAuu2A==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.28.tgz",
+      "integrity": "sha512-I4Iu4t9CdcoGwAWJLhPinGeXqFlgkX2rO+ua3eIk+aTv0/WrDWtPHPvgIVpl9n8VNXdEi2FcNi+C6GS6IGf0/A==",
       "requires": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dydxprotocol/governance": "^0.2.26",
+    "@dydxprotocol/governance": "^0.2.27",
     "@storybook/react": "^6.2.8",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dydxprotocol/governance": "^0.2.27",
+    "@dydxprotocol/governance": "^0.2.28",
     "@storybook/react": "^6.2.8",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",


### PR DESCRIPTION
`v0.2.27` increases gas limit estimations for `claimRewards` calls to claims proxy by 40% instead of 20%.