### PR TITLE
Bump governance to `v0.2.30`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@dydxprotocol/governance": "^0.2.28",
+        "@dydxprotocol/governance": "^0.2.29",
         "@storybook/react": "^6.2.8",
         "@testing-library/jest-dom": "^5.11.10",
         "@testing-library/react": "^11.2.6",
@@ -1614,9 +1614,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dydxprotocol/governance": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.28.tgz",
-      "integrity": "sha512-I4Iu4t9CdcoGwAWJLhPinGeXqFlgkX2rO+ua3eIk+aTv0/WrDWtPHPvgIVpl9n8VNXdEi2FcNi+C6GS6IGf0/A==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.29.tgz",
+      "integrity": "sha512-KHxuV/gX9Xj/yCQUs83hHfMlofAE5zxgleE5wV3fxanuUjSITDNqCjDc0f2Or6KxLfAXeUjr0i30ZfZVcIUZ1Q==",
       "dependencies": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",
@@ -42784,9 +42784,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dydxprotocol/governance": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.28.tgz",
-      "integrity": "sha512-I4Iu4t9CdcoGwAWJLhPinGeXqFlgkX2rO+ua3eIk+aTv0/WrDWtPHPvgIVpl9n8VNXdEi2FcNi+C6GS6IGf0/A==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.29.tgz",
+      "integrity": "sha512-KHxuV/gX9Xj/yCQUs83hHfMlofAE5zxgleE5wV3fxanuUjSITDNqCjDc0f2Or6KxLfAXeUjr0i30ZfZVcIUZ1Q==",
       "requires": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@dydxprotocol/governance": "^0.2.29",
+        "@dydxprotocol/governance": "^0.2.30",
         "@storybook/react": "^6.2.8",
         "@testing-library/jest-dom": "^5.11.10",
         "@testing-library/react": "^11.2.6",
@@ -1614,9 +1614,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dydxprotocol/governance": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.29.tgz",
-      "integrity": "sha512-KHxuV/gX9Xj/yCQUs83hHfMlofAE5zxgleE5wV3fxanuUjSITDNqCjDc0f2Or6KxLfAXeUjr0i30ZfZVcIUZ1Q==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.30.tgz",
+      "integrity": "sha512-RKEKUXzEbaZc61cmbKPdxRtb6XHleGrMhB1U69WANxvxclHjsQ87cOVzCQvl+Xkkd+otEVZUh+vEBy65iqgntw==",
       "dependencies": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",
@@ -42784,9 +42784,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dydxprotocol/governance": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.29.tgz",
-      "integrity": "sha512-KHxuV/gX9Xj/yCQUs83hHfMlofAE5zxgleE5wV3fxanuUjSITDNqCjDc0f2Or6KxLfAXeUjr0i30ZfZVcIUZ1Q==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/governance/-/governance-0.2.30.tgz",
+      "integrity": "sha512-RKEKUXzEbaZc61cmbKPdxRtb6XHleGrMhB1U69WANxvxclHjsQ87cOVzCQvl+Xkkd+otEVZUh+vEBy65iqgntw==",
       "requires": {
         "@chainlink/contracts": "^0.2.1",
         "@types/tmp": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dydxprotocol/governance": "^0.2.29",
+    "@dydxprotocol/governance": "^0.2.30",
     "@storybook/react": "^6.2.8",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dydxprotocol/governance": "^0.2.28",
+    "@dydxprotocol/governance": "^0.2.29",
     "@storybook/react": "^6.2.8",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",


### PR DESCRIPTION
Bump claims proxy gas limit to use 450k gas, which is above max gas limit used in claims proxy TXs. Will also help show which TXs are not using the suggested frontend gas limit.