### PR TITLE
Update voting power check on proposal details page

### DIFF
--- a/src/lib/contract-client/governance-client.ts
+++ b/src/lib/contract-client/governance-client.ts
@@ -168,6 +168,22 @@ class GovernanceClient {
     return txHashes;
   };
 
+  getVotingPowerAtBlock = async ({
+    block,
+    walletAddress,
+  }: {
+    block: number;
+    walletAddress: string;
+  }): Promise<string> => {
+    const votingPower = await this.txBuilder.dydxGovernanceService.getVotingPowerAt({
+      user: walletAddress,
+      block,
+      strategy: this.txBuilder.dydxGovernanceService.dydxGovernanceStrategyAddress,
+    });
+
+    return votingPower;
+  };
+
   getLatestProposals = async (): Promise<Proposal[]> => {
     const proposals = await this.txBuilder.dydxGovernanceService.getLatestProposals(10);
     return proposals;


### PR DESCRIPTION
Ability to vote is determined based on if the user has voting power at the time of the proposal start. Right now, we use the current block voting power to determine if the user can vote, not the start block of the proposal.