### PR TITLE
FE-619: Replace footer sitemap with horizontal layout

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+import { breakpoints } from 'styles';
+
+import type { LocalizationProps } from 'types';
+import { withLocalization } from '../hoc';
+
+import { Icon } from './Icon';
+import { CommonwealthIcon, DiscordIcon, TwitterIcon } from '../icons';
+
+import { STRING_KEYS } from '../constants/localization';
+
+const socialLinks: {
+  labelKey: string;
+  descriptionKey: string;
+  href: string;
+  icon?: React.FC;
+  isExternalLink?: boolean;
+}[] = [
+  {
+    labelKey: STRING_KEYS.DISCORD,
+    descriptionKey: STRING_KEYS.DISCORD_DESCRIPTION,
+    href: 'https://discord.gg/Tuze6tY',
+    icon: DiscordIcon,
+    isExternalLink: true,
+  },
+  {
+    labelKey: STRING_KEYS.TWITTER,
+    descriptionKey: STRING_KEYS.TWITTER_DESCRIPTION,
+    href: 'https://twitter.com/dydxfoundation',
+    icon: TwitterIcon,
+    isExternalLink: true,
+  },
+  {
+    labelKey: STRING_KEYS.FORUMS,
+    descriptionKey: STRING_KEYS.FORUMS_DESCRIPTION,
+    href: 'https://forums.dydx.community',
+    icon: CommonwealthIcon,
+    isExternalLink: true,
+  },
+];
+
+const legalLinks: {
+  labelKey: string;
+  descriptionKey: string;
+  href: string;
+  icon?: React.FC;
+  isExternalLink?: boolean;
+}[] = [
+  {
+    labelKey: STRING_KEYS.TERMS_OF_USE,
+    descriptionKey: STRING_KEYS.TERMS_OF_USE_DESCRIPTION,
+    href: 'https://dydx.foundation/terms',
+    isExternalLink: true,
+  },
+  {
+    labelKey: STRING_KEYS.PRIVACY_POLICY,
+    descriptionKey: STRING_KEYS.PRIVACY_POLICY_DESCRIPTION,
+    href: 'https://dydx.foundation/privacy',
+    isExternalLink: true,
+  },
+  {
+    labelKey: STRING_KEYS.REVOLVING_CREDIT_AGREEMENT,
+    descriptionKey: STRING_KEYS.REVOLVING_CREDIT_AGREEMENT_DESCRIPTION,
+    href: 'https://dydx.foundation/revolving-credit-agreement',
+    isExternalLink: true,
+  },
+];
+
+const Sitemap: React.FC<LocalizationProps> = ({ stringGetter }) => (
+  <StyledSitemap>
+    <nav>
+      <section className="social-links">
+        {socialLinks?.map((sublink) => (
+          <a
+            key={sublink.labelKey}
+            href={sublink.href}
+            {...(sublink.isExternalLink ? { target: '_blank', rel: 'noreferrer' } : {})}
+            title={`${stringGetter({ key: sublink.labelKey })} | ${stringGetter({
+              key: sublink.descriptionKey,
+            })}`}
+          >
+            <Icon icon={sublink.icon} />
+          </a>
+        ))}
+      </section>
+
+      <section>
+        {legalLinks?.map((sublink) => (
+          <a
+            key={sublink.labelKey}
+            href={sublink.href}
+            {...(sublink.isExternalLink ? { target: '_blank', rel: 'noreferrer' } : {})}
+          >
+            {stringGetter({ key: sublink.labelKey })}
+          </a>
+        ))}
+      </section>
+    </nav>
+  </StyledSitemap>
+);
+
+export default withLocalization(Sitemap);
+
+const StyledSitemap = styled.footer`
+  --color-text-light: #f7f7f7;
+  --color-text-base: #c3c2d4;
+  --color-text-dark: #6f6e84;
+
+  --color-border-grey: #2d2d3d;
+  --color-border-lighter: #393953;
+
+  --icon-size: 2.5;
+
+  display: grid;
+  z-index: 1;
+
+  background-color: ${({ theme }) => theme.layerbase};
+  box-shadow: 0px 0px 24px 8px rgba(26, 26, 39, 0.5);
+  border-top: 1px solid var(--color-border-grey);
+
+  width: 100%;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+
+  color: var(--color-text-base);
+  text-align: center;
+
+  * {
+    margin: 0;
+  }
+
+  a {
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+
+    transition: filter 0.2s;
+
+    &:hover {
+      filter: brightness(1.5);
+    }
+  }
+
+  > nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    @media ${breakpoints.mobile} {
+      flex-direction: column;
+    }
+
+    > section {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+
+      > a {
+        display: grid;
+        padding: 0.75em 1em;
+
+        > span {
+          color: var(--color-text-dark);
+          font-size: 0.825rem;
+        }
+      }
+    }
+  }
+`;

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -3,21 +3,18 @@ import styled from 'styled-components';
 import { breakpoints } from 'styles';
 
 const StyledIcon = styled.span`
-  --icon-size: 1.15;
-  --tablet-scale-factor: 1.1;
-
   align-self: center;
   vertical-align: middle;
 
   display: inline-grid;
 
   > svg {
-    width: calc(var(--icon-size) * 1em);
-    height: calc(var(--icon-size) * 1em);
+    width: calc(var(--icon-size, 1.15) * 1em);
+    height: calc(var(--icon-size, 1.15) * 1em);
   }
 
   @media ${breakpoints.tablet} {
-    font-size: calc(var(--tablet-scale-factor) * 1em);
+    font-size: calc(var(--tablet-scale-factor, 1.1) * 1em);
   }
 `;
 

--- a/src/components/Sitemap.tsx
+++ b/src/components/Sitemap.tsx
@@ -74,8 +74,8 @@ const links: {
   },
 ];
 
-const Footer: React.FC<LocalizationProps> = ({ stringGetter }) => (
-  <StyledFooter>
+const Sitemap: React.FC<LocalizationProps> = ({ stringGetter }) => (
+  <StyledSitemap>
     <nav>
       {links.map((link) => (
         <section key={link.labelKey}>
@@ -107,12 +107,12 @@ const Footer: React.FC<LocalizationProps> = ({ stringGetter }) => (
         </section>
       ))}
     </nav>
-  </StyledFooter>
+  </StyledSitemap>
 );
 
-export default withLocalization(Footer);
+export default withLocalization(Sitemap);
 
-const StyledFooter = styled.footer`
+const StyledSitemap = styled.footer`
   --color-text-light: #f7f7f7;
   --color-text-base: #c3c2d4;
   --color-text-dark: #6f6e84;


### PR DESCRIPTION
Keeping the old layout as a `<Sitemap>` component if we ever need it.

Before:

<img width="960" alt="Screen Shot 2022-08-11 at 3 22 35 PM" src="https://user-images.githubusercontent.com/13970789/184252707-ec45e5bb-d270-4c0f-9cf7-4cc2f195e4c7.png">

After:

<img width="1078" alt="Screen Shot 2022-08-11 at 3 22 16 PM" src="https://user-images.githubusercontent.com/13970789/184252839-9de52cfa-729e-4403-bad9-1d16f807c1ee.png">
