### PR TITLE
fix: include subpages in vercel.json>headers>source

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
     "headers": [
       {
-        "source": "/",
+        "source": "/(.*)",
         "headers": [
           {
             "key": "X-Content-Type-Options",


### PR DESCRIPTION
Currently, we have `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection` and `Content-Security-Policy` set for the  base URL, however the web app has a default redirect to `/dashboard`.

We should be returning these headers for all sub pages. 