### PR TITLE
Add rewrite to Pnyx vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "source": "/.*",
+      "source": "/(.*?)",
       "headers": [
         {
           "key": "X-Content-Type-Options",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,7 @@
 {
   "headers": [
     {
-      "source": "/(.*?)",
-      "destination": "/index.html",
+      "source": "/(.*)",
       "headers": [
         {
           "key": "X-Content-Type-Options",
@@ -22,5 +21,6 @@
         }
       ]
     }
-  ]
+  ],
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,25 +1,25 @@
 {
-    "headers": [
-      {
-        "source": "/(.*)",
-        "headers": [
-          {
-            "key": "X-Content-Type-Options",
-            "value": "nosniff"
-          },
-          {
-            "key": "X-Frame-Options",
-            "value": "SAMEORIGIN"
-          },
-          {
-            "key": "X-XSS-Protection",
-            "value": "1; mode=block"
-          },
-          {
-            "key": "Content-Security-Policy",
-            "value": "frame-ancestors 'none';"
-          }
-        ]
-      }
-    ]
-  }
+  "headers": [
+    {
+      "source": "/*",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none';"
+        }
+      ]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "source": "/*",
+      "source": "/.*",
       "headers": [
         {
           "key": "X-Content-Type-Options",

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "headers": [
     {
       "source": "/(.*?)",
+      "destination": "/index.html",
       "headers": [
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
Vercel does not work with `react-router` unless we add a rewrite definition in `vercel.json`. Using `/dashboard` as an example, the deployed application will try to access `/dashboard` file which does not exist because it is a route within `react-router`. Adding the rewrite solves this issue.