### PR TITLE
Reduce epoch distribution amount

### DIFF
--- a/src/hooks/useGetDistributionData.ts
+++ b/src/hooks/useGetDistributionData.ts
@@ -26,7 +26,7 @@ const useGetDistributionData = (): DistributionData => {
     const circulatingSupplyResponse = await contractClient.getCirculatingSupply();
     dispatch(setCirculatingSupply({ circulatingSupply: circulatingSupplyResponse }));
 
-    const distributedTodayResponse = '2732877'; // Distributed each epoch
+    const distributedTodayResponse = '2157534'; // Distributed each epoch
     dispatch(setDistributedToday({ distributedToday: distributedTodayResponse }));
 
     setCurrentDistributionData({


### PR DESCRIPTION
With the passing of [Proposal 14](https://dydx.community/dashboard/proposal/14) LP rewards will be reduced by 50% (575,343 DYDX/epoch).

The dashboard should be updated to display `2732877 - 575343` -> `2157534`.