### PR TITLE
hide circulating supply temporarily

### DIFF
--- a/src/pages/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/src/pages/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -95,7 +95,7 @@ const DashboardHeader: React.FC<
         {walletAddress ? <PortfolioModule /> : <DashboardHero />}
         <Cards>
           <CardContainer alignRight noMarginTop noWrap>
-            <ProgressBarCard
+            {/* <ProgressBarCard
               progress={circulatingSupplyPercent.toNumber()}
               progressBarLabels={{
                 topLeft: circulatingSupply ? (
@@ -126,7 +126,7 @@ const DashboardHeader: React.FC<
               }}
               size={CardSize.Small}
               title={stringGetter({ key: STRING_KEYS.CIRCULATING_SUPPLY })}
-            />
+            /> */}
             <SingleStatCard
               size={CardSize.Small}
               title={stringGetter({ key: STRING_KEYS.DISTRIBUTED_EACH_EPOCH })}


### PR DESCRIPTION
calculations for circulating supply is inaccurate and overestimated, will hide in UI until fix
<img width="1137" alt="image" src="https://github.com/dydxfoundation/pnyx/assets/9400120/f50bb862-1d04-4209-8314-f1d4787a7204">
